### PR TITLE
MOM-3827 Change default resultsPerPage

### DIFF
--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -49,7 +49,7 @@ export const DEFAULT_STATE: SearchState = {
   // Search Parameters -- This is state that represents the input state.
   current: 1,
   filters: [],
-  resultsPerPage: 20,
+  resultsPerPage: 25,
   searchTerm: "",
   sortDirection: "" as SortDirection,
   sortField: "",


### PR DESCRIPTION
There is a problem when the URL is changed outside of Search UI. We  compare the previous and current search driver states. Because `resultsPerPage` doesn't exist in the URL (we removed it) and our default `resultsPerPage` is 25 vs search ui's 20 is sees it as a change and fires a page view. It seems odd that Search UI doesn't merge in our initial state.

Before submitting this PR:

1. Make sure you are PR'ing from a fork, please do not push branches directly
   to this repository.
2. Ensure you've written sufficient tests for your work.
3. Double check that your changes will not break existing connectors (if
   applicable).
4. Double check that your changes do not break the `react-search-ui-views`
   storybook (if applicable).

## Description

## List of changes

## Associated Github Issues
